### PR TITLE
Add admin dashboard controller and views

### DIFF
--- a/backup-manager/app/Http/Controllers/ServerController.php
+++ b/backup-manager/app/Http/Controllers/ServerController.php
@@ -1,0 +1,13 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Server;
+
+class ServerController extends Controller
+{
+    public function index()
+    {
+        $servers = Server::all();
+        return view('dashboard', compact('servers'));
+    }
+}

--- a/backup-manager/resources/views/dashboard.blade.php
+++ b/backup-manager/resources/views/dashboard.blade.php
@@ -1,30 +1,29 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Dashboard</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss/dist/tailwind.min.css">
-</head>
-<body>
-<div class="container mx-auto p-4">
-    <h1 class="text-2xl font-bold mb-4">Servers</h1>
-    <table class="min-w-full bg-white">
-        <thead>
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <h1 class="mb-4">Servers Dashboard</h1>
+    <table class="table table-bordered">
+        <thead class="table-light">
             <tr>
-                <th class="px-4 py-2">Hostname</th>
-                <th class="px-4 py-2">IP</th>
-                <th class="px-4 py-2">Timezone</th>
+                <th>ID</th>
+                <th>Hostname</th>
+                <th>IP Address</th>
+                <th>Timezone</th>
             </tr>
         </thead>
         <tbody>
-            @foreach($servers as $server)
-            <tr class="border-t">
-                <td class="px-4 py-2">{{ $server->hostname }}</td>
-                <td class="px-4 py-2">{{ $server->ip }}</td>
-                <td class="px-4 py-2">{{ $server->timezone }}</td>
+        @forelse($servers as $server)
+            <tr>
+                <td>{{ $server->id }}</td>
+                <td>{{ $server->hostname }}</td>
+                <td>{{ $server->ip_address ?? $server->ip }}</td>
+                <td>{{ $server->timezone }}</td>
             </tr>
-            @endforeach
+        @empty
+            <tr><td colspan="4" class="text-center">No servers added yet</td></tr>
+        @endforelse
         </tbody>
     </table>
 </div>
-</body>
-</html>
+@endsection

--- a/backup-manager/resources/views/layouts/app.blade.php
+++ b/backup-manager/resources/views/layouts/app.blade.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>{{ config('app.name', 'Laravel') }}</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
+</head>
+<body>
+    <div id="app">
+        <main class="py-4">
+            @yield('content')
+        </main>
+    </div>
+</body>
+</html>

--- a/backup-manager/routes/web.php
+++ b/backup-manager/routes/web.php
@@ -1,18 +1,15 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider and all of them will
-| be assigned to the "web" middleware group. Make something great!
-|
-*/
+use Illuminate\Support\Facades\Auth;
+use App\Http\Controllers\ServerController;
 
 Route::get('/', function () {
-    return view('dashboard', ['servers' => \App\Models\Server::all()]);
+    return redirect()->route('dashboard');
 });
+
+Route::middleware(['auth'])->group(function () {
+    Route::get('/dashboard', [ServerController::class, 'index'])->name('dashboard');
+});
+
+Auth::routes();

--- a/backup-manager/tests/Feature/ExampleTest.php
+++ b/backup-manager/tests/Feature/ExampleTest.php
@@ -8,12 +8,11 @@ use Tests\TestCase;
 class ExampleTest extends TestCase
 {
     /**
-     * A basic test example.
+     * Basic application test.
      */
-    public function test_the_application_returns_a_successful_response(): void
+    public function test_root_redirects_to_dashboard(): void
     {
         $response = $this->get('/');
-
-        $response->assertStatus(200);
+        $response->assertRedirect('/dashboard');
     }
 }


### PR DESCRIPTION
## Summary
- add `ServerController` to list servers
- create Bootstrap layout and update dashboard view
- secure dashboard route with authentication and redirect from `/`
- adjust example test for new dashboard route

## Testing
- `php artisan --version` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fc109c0cc83249d2f2e3f96586e5d