### PR TITLE
Add full server CRUD with role permissions

### DIFF
--- a/backup-manager/app/Http/Controllers/ServerController.php
+++ b/backup-manager/app/Http/Controllers/ServerController.php
@@ -2,12 +2,70 @@
 namespace App\Http\Controllers;
 
 use App\Models\Server;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class ServerController extends Controller
 {
     public function index()
     {
         $servers = Server::all();
-        return view('dashboard', compact('servers'));
+        return view('servers.index', compact('servers'));
+    }
+
+    public function create()
+    {
+        $this->authorizeAction(['admin', 'manager']);
+        return view('servers.create');
+    }
+
+    public function store(Request $request)
+    {
+        $this->authorizeAction(['admin', 'manager']);
+
+        $validated = $request->validate([
+            'hostname' => 'required',
+            'ip' => 'required|ip',
+            'timezone' => 'required',
+        ]);
+
+        Server::create($validated);
+
+        return redirect()->route('servers.index');
+    }
+
+    public function edit(Server $server)
+    {
+        $this->authorizeAction(['admin', 'manager']);
+        return view('servers.edit', compact('server'));
+    }
+
+    public function update(Request $request, Server $server)
+    {
+        $this->authorizeAction(['admin', 'manager']);
+
+        $validated = $request->validate([
+            'hostname' => 'required',
+            'ip' => 'required|ip',
+            'timezone' => 'required',
+        ]);
+
+        $server->update($validated);
+
+        return redirect()->route('servers.index');
+    }
+
+    public function destroy(Server $server)
+    {
+        $this->authorizeAction(['admin']);
+        $server->delete();
+        return redirect()->route('servers.index');
+    }
+
+    private function authorizeAction(array $roles)
+    {
+        if (!in_array(Auth::user()->role, $roles)) {
+            abort(403);
+        }
     }
 }

--- a/backup-manager/resources/views/layouts/app.blade.php
+++ b/backup-manager/resources/views/layouts/app.blade.php
@@ -12,6 +12,36 @@
 </head>
 <body>
     <div id="app">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light">
+            <div class="container">
+                <a class="navbar-brand" href="{{ url('/') }}">{{ config('app.name', 'Laravel') }}</a>
+                <div class="collapse navbar-collapse">
+                    <ul class="navbar-nav me-auto">
+                        @auth
+                        <li class="nav-item"><a class="nav-link" href="{{ route('servers.index') }}">Servers</a></li>
+                        @endauth
+                    </ul>
+                    <ul class="navbar-nav ms-auto">
+                        @guest
+                            <li class="nav-item"><a class="nav-link" href="{{ route('login') }}">Login</a></li>
+                            <li class="nav-item"><a class="nav-link" href="{{ route('register') }}">Register</a></li>
+                        @else
+                            <li class="nav-item dropdown">
+                                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">{{ Auth::user()->name }}</a>
+                                <ul class="dropdown-menu dropdown-menu-end">
+                                    <li>
+                                        <a class="dropdown-item" href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">Logout</a>
+                                        <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
+                                            @csrf
+                                        </form>
+                                    </li>
+                                </ul>
+                            </li>
+                        @endguest
+                    </ul>
+                </div>
+            </div>
+        </nav>
         <main class="py-4">
             @yield('content')
         </main>

--- a/backup-manager/resources/views/servers/create.blade.php
+++ b/backup-manager/resources/views/servers/create.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <h1 class="mb-4">Add Server</h1>
+    <form action="{{ route('servers.store') }}" method="POST">
+        @csrf
+        <div class="mb-3">
+            <label class="form-label">Hostname</label>
+            <input type="text" name="hostname" class="form-control" value="{{ old('hostname') }}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">IP Address</label>
+            <input type="text" name="ip" class="form-control" value="{{ old('ip') }}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Timezone</label>
+            <input type="text" name="timezone" class="form-control" value="{{ old('timezone') }}" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+</div>
+@endsection

--- a/backup-manager/resources/views/servers/edit.blade.php
+++ b/backup-manager/resources/views/servers/edit.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <h1 class="mb-4">Edit Server</h1>
+    <form action="{{ route('servers.update', $server) }}" method="POST">
+        @csrf
+        @method('PUT')
+        <div class="mb-3">
+            <label class="form-label">Hostname</label>
+            <input type="text" name="hostname" class="form-control" value="{{ old('hostname', $server->hostname) }}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">IP Address</label>
+            <input type="text" name="ip" class="form-control" value="{{ old('ip', $server->ip) }}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Timezone</label>
+            <input type="text" name="timezone" class="form-control" value="{{ old('timezone', $server->timezone) }}" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Update</button>
+    </form>
+</div>
+@endsection

--- a/backup-manager/resources/views/servers/index.blade.php
+++ b/backup-manager/resources/views/servers/index.blade.php
@@ -1,0 +1,51 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="d-flex justify-content-between mb-3">
+        <h1>Servers</h1>
+        @if(auth()->user()->role !== 'viewer')
+            <a href="{{ route('servers.create') }}" class="btn btn-primary">Add Server</a>
+        @endif
+    </div>
+    <table class="table table-bordered">
+        <thead class="table-light">
+            <tr>
+                <th>ID</th>
+                <th>Hostname</th>
+                <th>IP Address</th>
+                <th>Timezone</th>
+                @if(auth()->user()->role !== 'viewer')
+                    <th>Actions</th>
+                @endif
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($servers as $server)
+            <tr>
+                <td>{{ $server->id }}</td>
+                <td>{{ $server->hostname }}</td>
+                <td>{{ $server->ip }}</td>
+                <td>{{ $server->timezone }}</td>
+                @if(auth()->user()->role !== 'viewer')
+                <td>
+                    <a href="{{ route('servers.edit', $server) }}" class="btn btn-sm btn-secondary">Edit</a>
+                    @if(auth()->user()->role === 'admin')
+                    <form action="{{ route('servers.destroy', $server) }}" method="POST" class="d-inline" onsubmit="return confirm('Delete this server?');">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                    </form>
+                    @endif
+                </td>
+                @endif
+            </tr>
+            @empty
+            <tr>
+                <td colspan="{{ auth()->user()->role !== 'viewer' ? 5 : 4 }}" class="text-center">No servers added yet</td>
+            </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/backup-manager/routes/web.php
+++ b/backup-manager/routes/web.php
@@ -5,11 +5,11 @@ use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\ServerController;
 
 Route::get('/', function () {
-    return redirect()->route('dashboard');
+    return redirect()->route('servers.index');
 });
 
 Route::middleware(['auth'])->group(function () {
-    Route::get('/dashboard', [ServerController::class, 'index'])->name('dashboard');
+    Route::resource('servers', ServerController::class)->except(['show']);
 });
 
 Auth::routes();


### PR DESCRIPTION
## Summary
- add `servers` resource routes
- implement `ServerController` with CRUD methods and role checks
- add Bootstrap navbar with link to Servers
- create `servers` Blade views for listing, creating, and editing

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fca3c1e2c83248d6adea1a2ef0e28