### PR TITLE
Add default admin seeder

### DIFF
--- a/backup-manager/database/seeders/DatabaseSeeder.php
+++ b/backup-manager/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,13 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        \App\Models\User::firstOrCreate(
+            ['email' => 'admin@example.com'],
+            [
+                'name' => 'Admin',
+                'password' => bcrypt('admin123'),
+                'role' => 'admin',
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- seed the database with a default admin user

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdb16ee108324840db87eb8853123