### PR TITLE
Implement default admin seeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Backup Manager is a Laravel 10.x application used to register servers and plan t
 3. From the project directory run `composer install`.
 4. Copy `.env.example` to `.env` and adjust the database credentials.
 5. Run `php artisan key:generate` followed by `php artisan migrate`.
+6. (Optional) Seed a default admin user with `php artisan db:seed`.
 
 ## Future Ideas
 

--- a/backup-manager/database/factories/UserFactory.php
+++ b/backup-manager/database/factories/UserFactory.php
@@ -28,6 +28,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'role' => fake()->randomElement(['admin','manager','viewer']),
             'remember_token' => Str::random(10),
         ];
     }

--- a/backup-manager/database/seeders/DatabaseSeeder.php
+++ b/backup-manager/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,14 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        // Create a default admin user if none exists
+        \App\Models\User::firstOrCreate([
+            'email' => 'admin@example.com',
+        ], [
+            'name' => 'Admin',
+            'password' => bcrypt('admin123'),
+            'role' => 'admin',
+            'email_verified_at' => now(),
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- seed a default admin user
- generate random roles in `UserFactory`
- document database seeding in README

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdb16ee108324840db87eb8853123