### PR TITLE
Add role-based middleware

### DIFF
--- a/backup-manager/app/Http/Controllers/BackupServerController.php
+++ b/backup-manager/app/Http/Controllers/BackupServerController.php
@@ -3,7 +3,6 @@ namespace App\Http\Controllers;
 
 use App\Models\BackupServer;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class BackupServerController extends Controller
 {
@@ -15,13 +14,11 @@ class BackupServerController extends Controller
 
     public function create()
     {
-        $this->authorizeAction(['admin', 'manager']);
         return view('backup_servers.create');
     }
 
     public function store(Request $request)
     {
-        $this->authorizeAction(['admin', 'manager']);
 
         $validated = $request->validate([
             'name' => 'required',
@@ -36,13 +33,11 @@ class BackupServerController extends Controller
 
     public function edit(BackupServer $backupServer)
     {
-        $this->authorizeAction(['admin', 'manager']);
         return view('backup_servers.edit', compact('backupServer'));
     }
 
     public function update(Request $request, BackupServer $backupServer)
     {
-        $this->authorizeAction(['admin', 'manager']);
 
         $validated = $request->validate([
             'name' => 'required',
@@ -57,15 +52,8 @@ class BackupServerController extends Controller
 
     public function destroy(BackupServer $backupServer)
     {
-        $this->authorizeAction(['admin']);
         $backupServer->delete();
         return redirect()->route('backup-servers.index')->with('success', 'Backup server deleted');
     }
 
-    private function authorizeAction(array $roles)
-    {
-        if (!in_array(Auth::user()->role, $roles)) {
-            abort(403);
-        }
-    }
 }

--- a/backup-manager/app/Http/Controllers/LicenseController.php
+++ b/backup-manager/app/Http/Controllers/LicenseController.php
@@ -5,7 +5,6 @@ use App\Models\License;
 use App\Models\LicenseGroup;
 use App\Models\Server;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class LicenseController extends Controller
 {
@@ -17,7 +16,6 @@ class LicenseController extends Controller
 
     public function create()
     {
-        $this->authorizeAction(['admin', 'manager']);
         $servers = Server::all();
         $groups = LicenseGroup::all();
         return view('licenses.create', compact('servers', 'groups'));
@@ -25,7 +23,6 @@ class LicenseController extends Controller
 
     public function store(Request $request)
     {
-        $this->authorizeAction(['admin', 'manager']);
 
         $validated = $request->validate([
             'server_id' => 'required|exists:servers,id',
@@ -40,7 +37,6 @@ class LicenseController extends Controller
 
     public function edit(License $license)
     {
-        $this->authorizeAction(['admin', 'manager']);
         $servers = Server::all();
         $groups = LicenseGroup::all();
         return view('licenses.edit', compact('license', 'servers', 'groups'));
@@ -48,7 +44,6 @@ class LicenseController extends Controller
 
     public function update(Request $request, License $license)
     {
-        $this->authorizeAction(['admin', 'manager']);
 
         $validated = $request->validate([
             'server_id' => 'required|exists:servers,id',
@@ -63,15 +58,8 @@ class LicenseController extends Controller
 
     public function destroy(License $license)
     {
-        $this->authorizeAction(['admin']);
         $license->delete();
         return redirect()->route('licenses.index')->with('success', 'License deleted');
     }
 
-    private function authorizeAction(array $roles)
-    {
-        if (!in_array(Auth::user()->role, $roles)) {
-            abort(403);
-        }
-    }
 }

--- a/backup-manager/app/Http/Controllers/LicenseGroupController.php
+++ b/backup-manager/app/Http/Controllers/LicenseGroupController.php
@@ -3,7 +3,6 @@ namespace App\Http\Controllers;
 
 use App\Models\LicenseGroup;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class LicenseGroupController extends Controller
 {
@@ -15,13 +14,11 @@ class LicenseGroupController extends Controller
 
     public function create()
     {
-        $this->authorizeAction(['admin', 'manager']);
         return view('license_groups.create');
     }
 
     public function store(Request $request)
     {
-        $this->authorizeAction(['admin', 'manager']);
 
         $validated = $request->validate([
             'name' => 'required',
@@ -33,13 +30,11 @@ class LicenseGroupController extends Controller
 
     public function edit(LicenseGroup $licenseGroup)
     {
-        $this->authorizeAction(['admin', 'manager']);
         return view('license_groups.edit', compact('licenseGroup'));
     }
 
     public function update(Request $request, LicenseGroup $licenseGroup)
     {
-        $this->authorizeAction(['admin', 'manager']);
 
         $validated = $request->validate([
             'name' => 'required',
@@ -51,15 +46,8 @@ class LicenseGroupController extends Controller
 
     public function destroy(LicenseGroup $licenseGroup)
     {
-        $this->authorizeAction(['admin']);
         $licenseGroup->delete();
         return redirect()->route('license-groups.index')->with('success', 'License group deleted');
     }
 
-    private function authorizeAction(array $roles)
-    {
-        if (!in_array(Auth::user()->role, $roles)) {
-            abort(403);
-        }
-    }
 }

--- a/backup-manager/app/Http/Controllers/ServerBackupController.php
+++ b/backup-manager/app/Http/Controllers/ServerBackupController.php
@@ -5,7 +5,6 @@ use App\Models\ServerBackup;
 use App\Models\Server;
 use App\Models\BackupServer;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class ServerBackupController extends Controller
 {
@@ -17,7 +16,6 @@ class ServerBackupController extends Controller
 
     public function create()
     {
-        $this->authorizeAction(['admin', 'manager']);
         $servers = Server::all();
         $backupServers = BackupServer::all();
         return view('server_backups.create', compact('servers', 'backupServers'));
@@ -25,7 +23,6 @@ class ServerBackupController extends Controller
 
     public function store(Request $request)
     {
-        $this->authorizeAction(['admin', 'manager']);
 
         $validated = $request->validate([
             'server_id' => 'required|exists:servers,id',
@@ -41,7 +38,6 @@ class ServerBackupController extends Controller
 
     public function edit(ServerBackup $serverBackup)
     {
-        $this->authorizeAction(['admin', 'manager']);
         $servers = Server::all();
         $backupServers = BackupServer::all();
         return view('server_backups.edit', compact('serverBackup', 'servers', 'backupServers'));
@@ -49,7 +45,6 @@ class ServerBackupController extends Controller
 
     public function update(Request $request, ServerBackup $serverBackup)
     {
-        $this->authorizeAction(['admin', 'manager']);
 
         $validated = $request->validate([
             'server_id' => 'required|exists:servers,id',
@@ -65,15 +60,8 @@ class ServerBackupController extends Controller
 
     public function destroy(ServerBackup $serverBackup)
     {
-        $this->authorizeAction(['admin']);
         $serverBackup->delete();
         return redirect()->route('server-backups.index')->with('success', 'Assignment deleted');
     }
 
-    private function authorizeAction(array $roles)
-    {
-        if (!in_array(Auth::user()->role, $roles)) {
-            abort(403);
-        }
-    }
 }

--- a/backup-manager/app/Http/Controllers/ServerController.php
+++ b/backup-manager/app/Http/Controllers/ServerController.php
@@ -3,7 +3,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Server;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class ServerController extends Controller
 {
@@ -15,13 +14,13 @@ class ServerController extends Controller
 
     public function create()
     {
-        $this->authorizeAction(['admin', 'manager']);
+        
         return view('servers.create');
     }
 
     public function store(Request $request)
     {
-        $this->authorizeAction(['admin', 'manager']);
+
 
         $validated = $request->validate([
             'hostname' => 'required',
@@ -36,13 +35,13 @@ class ServerController extends Controller
 
     public function edit(Server $server)
     {
-        $this->authorizeAction(['admin', 'manager']);
+
         return view('servers.edit', compact('server'));
     }
 
     public function update(Request $request, Server $server)
     {
-        $this->authorizeAction(['admin', 'manager']);
+
 
         $validated = $request->validate([
             'hostname' => 'required',
@@ -57,15 +56,9 @@ class ServerController extends Controller
 
     public function destroy(Server $server)
     {
-        $this->authorizeAction(['admin']);
+
         $server->delete();
         return redirect()->route('servers.index')->with('success', 'Server deleted');
     }
 
-    private function authorizeAction(array $roles)
-    {
-        if (!in_array(Auth::user()->role, $roles)) {
-            abort(403);
-        }
-    }
 }

--- a/backup-manager/app/Http/Controllers/UserController.php
+++ b/backup-manager/app/Http/Controllers/UserController.php
@@ -3,27 +3,23 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 
 class UserController extends Controller
 {
     public function index()
     {
-        $this->authorizeAction(['admin']);
         $users = User::all();
         return view('users.index', compact('users'));
     }
 
     public function edit(User $user)
     {
-        $this->authorizeAction(['admin']);
         return view('users.edit', compact('user'));
     }
 
     public function update(Request $request, User $user)
     {
-        $this->authorizeAction(['admin']);
         $validated = $request->validate([
             'name' => 'required',
             'email' => 'required|email',
@@ -43,15 +39,8 @@ class UserController extends Controller
 
     public function destroy(User $user)
     {
-        $this->authorizeAction(['admin']);
         $user->delete();
         return redirect()->route('users.index')->with('success', 'User deleted');
     }
 
-    private function authorizeAction(array $roles)
-    {
-        if (!in_array(Auth::user()->role, $roles)) {
-            abort(403);
-        }
-    }
 }

--- a/backup-manager/app/Http/Kernel.php
+++ b/backup-manager/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'role' => \App\Http\Middleware\CheckRole::class,
     ];
 }

--- a/backup-manager/app/Http/Middleware/CheckRole.php
+++ b/backup-manager/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (Response)  $next
+     * @param  mixed  ...$roles
+     * @return Response
+     */
+    public function handle($request, Closure $next, ...$roles)
+    {
+        $user = Auth::user();
+
+        if (!$user || !in_array($user->role, $roles)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/backup-manager/routes/web.php
+++ b/backup-manager/routes/web.php
@@ -16,12 +16,29 @@ Route::get('/', function () {
 
 Route::middleware(['auth'])->group(function () {
     Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
-    Route::resource('servers', ServerController::class)->except(['show']);
-    Route::resource('backup-servers', BackupServerController::class)->except(['show']);
-    Route::resource('server-backups', ServerBackupController::class)->except(['show']);
-    Route::resource('license-groups', LicenseGroupController::class)->except(['show']);
-    Route::resource('licenses', LicenseController::class)->except(['show']);
-    Route::resource('users', UserController::class)->except(['show', 'create', 'store']);
+
+    Route::resource('servers', ServerController::class)->only(['index']);
+    Route::resource('backup-servers', BackupServerController::class)->only(['index']);
+    Route::resource('server-backups', ServerBackupController::class)->only(['index']);
+    Route::resource('license-groups', LicenseGroupController::class)->only(['index']);
+    Route::resource('licenses', LicenseController::class)->only(['index']);
+
+    Route::middleware('role:admin,manager')->group(function () {
+        Route::resource('servers', ServerController::class)->only(['create','store','edit','update']);
+        Route::resource('backup-servers', BackupServerController::class)->only(['create','store','edit','update']);
+        Route::resource('server-backups', ServerBackupController::class)->only(['create','store','edit','update']);
+        Route::resource('license-groups', LicenseGroupController::class)->only(['create','store','edit','update']);
+        Route::resource('licenses', LicenseController::class)->only(['create','store','edit','update']);
+    });
+
+    Route::middleware('role:admin')->group(function () {
+        Route::resource('servers', ServerController::class)->only(['destroy']);
+        Route::resource('backup-servers', BackupServerController::class)->only(['destroy']);
+        Route::resource('server-backups', ServerBackupController::class)->only(['destroy']);
+        Route::resource('license-groups', LicenseGroupController::class)->only(['destroy']);
+        Route::resource('licenses', LicenseController::class)->only(['destroy']);
+        Route::resource('users', UserController::class)->except(['show', 'create', 'store']);
+    });
 });
 
 Auth::routes();


### PR DESCRIPTION
## Summary
- implement `CheckRole` middleware to handle role checks
- register `role` alias in kernel
- apply role middleware in `web.php` route groups
- remove in-controller role checks

## Testing
- `vendor/bin/phpunit --filter dummy` *(fails: `vendor/bin/phpunit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fde689e788324aa443c3db7d1d167