### PR TITLE
Add admin seeder and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Backup Manager is a Laravel 10.x application used to register servers and plan t
 3. From the project directory run `composer install`.
 4. Copy `.env.example` to `.env` and adjust the database credentials.
 5. Run `php artisan key:generate` followed by `php artisan migrate`.
+6. Seed the database with an admin user using `php artisan db:seed`.
 
 ## Future Ideas
 

--- a/backup-manager/database/seeders/DatabaseSeeder.php
+++ b/backup-manager/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,8 @@ namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -12,11 +14,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        User::firstOrCreate(
+            [
+                'email' => 'admin@example.com',
+            ],
+            [
+                'name' => 'Admin',
+                'password' => Hash::make('admin123'),
+                'role' => 'admin',
+                'email_verified_at' => now(),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- seed a default admin user in `DatabaseSeeder`
- add database seeding instructions to the README

## Testing
- `composer install --no-interaction` *(fails: composer not installed)*
- `php artisan --version` *(fails: php not installed)*
- `./vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fde681df88324b16c05a6ad0a508a