### PR TITLE
Expand server schema and forms

### DIFF
--- a/backup-manager/app/Http/Controllers/ServerController.php
+++ b/backup-manager/app/Http/Controllers/ServerController.php
@@ -26,7 +26,17 @@ class ServerController extends Controller
         $validated = $request->validate([
             'hostname' => 'required',
             'ip' => 'required|ip',
+            'dns' => 'nullable',
+            'vnc' => 'nullable',
+            'control_panel' => 'nullable',
+            'backup_time' => 'nullable|date_format:H:i',
+            'username' => 'nullable',
+            'password' => 'nullable',
+            'license_reference' => 'nullable',
+            'node_group' => 'nullable',
+            'data_center' => 'nullable',
             'timezone' => 'required',
+            'notes' => 'nullable',
         ]);
 
         Server::create($validated);
@@ -47,7 +57,17 @@ class ServerController extends Controller
         $validated = $request->validate([
             'hostname' => 'required',
             'ip' => 'required|ip',
+            'dns' => 'nullable',
+            'vnc' => 'nullable',
+            'control_panel' => 'nullable',
+            'backup_time' => 'nullable|date_format:H:i',
+            'username' => 'nullable',
+            'password' => 'nullable',
+            'license_reference' => 'nullable',
+            'node_group' => 'nullable',
+            'data_center' => 'nullable',
             'timezone' => 'required',
+            'notes' => 'nullable',
         ]);
 
         $server->update($validated);

--- a/backup-manager/app/Models/Server.php
+++ b/backup-manager/app/Models/Server.php
@@ -14,8 +14,15 @@ class Server extends Model
     protected $fillable = [
         'hostname',
         'ip',
+        'dns',
         'vnc',
         'control_panel',
+        'backup_time',
+        'username',
+        'password',
+        'license_reference',
+        'node_group',
+        'data_center',
         'timezone',
         'notes',
     ];

--- a/backup-manager/database/migrations/2025_06_16_002316_create_servers_table.php
+++ b/backup-manager/database/migrations/2025_06_16_002316_create_servers_table.php
@@ -15,8 +15,15 @@ return new class extends Migration
             $table->id();
             $table->string('hostname');
             $table->string('ip');
+            $table->string('dns')->nullable();
             $table->string('vnc')->nullable();
             $table->string('control_panel')->nullable();
+            $table->time('backup_time')->nullable();
+            $table->string('username')->nullable();
+            $table->string('password')->nullable();
+            $table->string('license_reference')->nullable();
+            $table->string('node_group')->nullable();
+            $table->string('data_center')->nullable();
             $table->string('timezone')->default('UTC');
             $table->text('notes')->nullable();
             $table->timestamps();

--- a/backup-manager/resources/views/servers/create.blade.php
+++ b/backup-manager/resources/views/servers/create.blade.php
@@ -14,8 +14,58 @@
             <input type="text" name="ip" class="form-control" value="{{ old('ip') }}" required>
         </div>
         <div class="mb-3">
+            <label class="form-label">DNS</label>
+            <input type="text" name="dns" class="form-control" value="{{ old('dns') }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">VNC</label>
+            <input type="text" name="vnc" class="form-control" value="{{ old('vnc') }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Control Panel</label>
+            <select name="control_panel" class="form-select">
+                <option value="">None</option>
+                <option value="cPanel">cPanel</option>
+                <option value="Plesk">Plesk</option>
+                <option value="DirectAdmin">DirectAdmin</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Backup Time</label>
+            <input type="time" name="backup_time" class="form-control" value="{{ old('backup_time') }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Username</label>
+            <input type="text" name="username" class="form-control" value="{{ old('username') }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input type="text" name="password" class="form-control" value="{{ old('password') }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">License Reference</label>
+            <input type="text" name="license_reference" class="form-control" value="{{ old('license_reference') }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Node Group</label>
+            <input type="text" name="node_group" class="form-control" value="{{ old('node_group') }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Data Center</label>
+            <input type="text" name="data_center" class="form-control" value="{{ old('data_center') }}">
+        </div>
+        <div class="mb-3">
             <label class="form-label">Timezone</label>
-            <input type="text" name="timezone" class="form-control" value="{{ old('timezone') }}" required>
+            <select name="timezone" class="form-select" required>
+                <option value="UTC" @selected(old('timezone')==='UTC')>UTC</option>
+                <option value="America/New_York" @selected(old('timezone')==='America/New_York')>America/New_York</option>
+                <option value="Europe/London" @selected(old('timezone')==='Europe/London')>Europe/London</option>
+                <option value="Asia/Tokyo" @selected(old('timezone')==='Asia/Tokyo')>Asia/Tokyo</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Notes</label>
+            <textarea name="notes" class="form-control">{{ old('notes') }}</textarea>
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
     </form>

--- a/backup-manager/resources/views/servers/edit.blade.php
+++ b/backup-manager/resources/views/servers/edit.blade.php
@@ -15,8 +15,58 @@
             <input type="text" name="ip" class="form-control" value="{{ old('ip', $server->ip) }}" required>
         </div>
         <div class="mb-3">
+            <label class="form-label">DNS</label>
+            <input type="text" name="dns" class="form-control" value="{{ old('dns', $server->dns) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">VNC</label>
+            <input type="text" name="vnc" class="form-control" value="{{ old('vnc', $server->vnc) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Control Panel</label>
+            <select name="control_panel" class="form-select">
+                <option value="" @selected($server->control_panel==='')>None</option>
+                <option value="cPanel" @selected($server->control_panel==='cPanel')>cPanel</option>
+                <option value="Plesk" @selected($server->control_panel==='Plesk')>Plesk</option>
+                <option value="DirectAdmin" @selected($server->control_panel==='DirectAdmin')>DirectAdmin</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Backup Time</label>
+            <input type="time" name="backup_time" class="form-control" value="{{ old('backup_time', $server->backup_time) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Username</label>
+            <input type="text" name="username" class="form-control" value="{{ old('username', $server->username) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input type="text" name="password" class="form-control" value="{{ old('password', $server->password) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">License Reference</label>
+            <input type="text" name="license_reference" class="form-control" value="{{ old('license_reference', $server->license_reference) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Node Group</label>
+            <input type="text" name="node_group" class="form-control" value="{{ old('node_group', $server->node_group) }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Data Center</label>
+            <input type="text" name="data_center" class="form-control" value="{{ old('data_center', $server->data_center) }}">
+        </div>
+        <div class="mb-3">
             <label class="form-label">Timezone</label>
-            <input type="text" name="timezone" class="form-control" value="{{ old('timezone', $server->timezone) }}" required>
+            <select name="timezone" class="form-select" required>
+                <option value="UTC" @selected(old('timezone', $server->timezone)==='UTC')>UTC</option>
+                <option value="America/New_York" @selected(old('timezone', $server->timezone)==='America/New_York')>America/New_York</option>
+                <option value="Europe/London" @selected(old('timezone', $server->timezone)==='Europe/London')>Europe/London</option>
+                <option value="Asia/Tokyo" @selected(old('timezone', $server->timezone)==='Asia/Tokyo')>Asia/Tokyo</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Notes</label>
+            <textarea name="notes" class="form-control">{{ old('notes', $server->notes) }}</textarea>
         </div>
         <button type="submit" class="btn btn-primary">Update</button>
     </form>


### PR DESCRIPTION
## Summary
- expand server migration with extra metadata fields
- sync Server `$fillable` with new columns
- validate new data in `ServerController`
- update create/edit server views with new dropdowns and time picker

## Testing
- `./vendor/bin/phpunit --filter ExampleTest --stop-on-failure` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684fde66d13c83248f62355ec8d97814