### PR TITLE
Add admin seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,18 +2,17 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\Hash;
 use App\Models\User;
 
 class DatabaseSeeder extends Seeder
 {
     public function run()
     {
-        User::create([
+        \App\Models\User::create([
             'name' => 'Admin',
             'email' => 'admin@example.com',
-            'password' => Hash::make('admin123'),
-            'role' => 'admin',
+            'password' => bcrypt('admin123'),
+            'role' => 'admin'
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- seed default admin user using bcrypt

## Testing
- `php artisan key:generate` *(fails: vendor autoload not found)*
- `php artisan migrate` *(fails: vendor autoload not found)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffb8570788324aee386e80a92fd9e