### PR TITLE
Fix DatabaseSeeder autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/"
+            "App\\": "app/",
+            "Database\\Factories\\": "database/factories/",
+            "Database\\Seeders\\": "database/seeders/"
         }
     },
     "scripts": {


### PR DESCRIPTION
## Summary
- update composer.json autoload so Laravel can find Database\Seeders

## Testing
- `composer dump-autoload`
- `php artisan db:seed --force` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_685001a46ec08324b6e47df55bf66f7a