### PR TITLE
Enable creating servers

### DIFF
--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -1,6 +1,9 @@
 <?php
 namespace App\Http\Controllers;
 
+use Illuminate\Http\Request;
+use App\Models\Server;
+
 class ServerController extends Controller
 {
     public function __construct()
@@ -10,7 +13,26 @@ class ServerController extends Controller
 
     public function index()
     {
-        $servers = \App\Models\Server::all();
+        $servers = Server::all();
         return view('servers.index', compact('servers'));
+    }
+
+    public function create()
+    {
+        return view('servers.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'hostname' => 'required|string|max:255',
+            'ip_address' => 'required|string|max:255',
+            'timezone' => 'required|string|max:255',
+        ]);
+
+        Server::create($data);
+
+        return redirect()->route('servers.index')
+                         ->with('success', 'Server created successfully.');
     }
 }

--- a/resources/views/servers/create.blade.php
+++ b/resources/views/servers/create.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Add Server</h1>
+    <form method="POST" action="{{ route('servers.store') }}">
+        @csrf
+        <div class="mb-3">
+            <label for="hostname" class="form-label">Hostname</label>
+            <input type="text" name="hostname" id="hostname" class="form-control" value="{{ old('hostname') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="ip_address" class="form-label">IP Address</label>
+            <input type="text" name="ip_address" id="ip_address" class="form-control" value="{{ old('ip_address') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="timezone" class="form-label">Timezone</label>
+            <input type="text" name="timezone" id="timezone" class="form-control" value="{{ old('timezone', 'UTC') }}" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <a href="{{ route('servers.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/servers/index.blade.php
+++ b/resources/views/servers/index.blade.php
@@ -4,6 +4,12 @@
 <div class="container">
     <h1>Servers</h1>
 
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+
+    <a href="{{ route('servers.create') }}" class="btn btn-primary mb-3">Add Server</a>
+
     <table class="table table-bordered">
         <thead>
             <tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/dashboard', [App\Http\Controllers\HomeController::class, 'index'])->name('dashboard');
 
     Route::get('/servers', [App\Http\Controllers\ServerController::class, 'index'])->name('servers.index');
+    Route::get('/servers/create', [App\Http\Controllers\ServerController::class, 'create'])->name('servers.create');
+    Route::post('/servers', [App\Http\Controllers\ServerController::class, 'store'])->name('servers.store');
 
     Route::get('/clients-servers', [App\Http\Controllers\ClientServerController::class, 'index'])->name('client-servers.index');
 


### PR DESCRIPTION
## Summary
- implement create/store actions for servers
- show create link and success messages on server list
- add server creation form
- register create/store routes

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502c28881c832491fb5e1f18ccf17d