### PR TITLE
Add create routes and forms

### DIFF
--- a/app/Http/Controllers/ClientServerController.php
+++ b/app/Http/Controllers/ClientServerController.php
@@ -13,4 +13,26 @@ class ClientServerController extends Controller
         $clientServers = \App\Models\ClientServer::all();
         return view('client-servers.index', compact('clientServers'));
     }
+
+    public function create()
+    {
+        return view('client-servers.create');
+    }
+
+    public function store(\Illuminate\Http\Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'ip_address' => 'required|string|max:255',
+            'type' => 'required|string|max:255',
+            'timezone' => 'required|string|max:255',
+            'username' => 'required|string|max:255',
+            'password' => 'required|string|max:255',
+        ]);
+
+        \App\Models\ClientServer::create($data);
+
+        return redirect()->route('client-servers.index')
+                         ->with('success', 'Client server created successfully.');
+    }
 }

--- a/app/Http/Controllers/LicenseController.php
+++ b/app/Http/Controllers/LicenseController.php
@@ -13,4 +13,25 @@ class LicenseController extends Controller
         $licenses = \App\Models\License::all();
         return view('licenses.index', compact('licenses'));
     }
+
+    public function create()
+    {
+        return view('licenses.create');
+    }
+
+    public function store(\Illuminate\Http\Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'license_key' => 'required|string|max:255',
+            'provider' => 'nullable|string|max:255',
+            'type' => 'nullable|string|max:255',
+            'status' => 'nullable|string|max:255',
+        ]);
+
+        \App\Models\License::create($data);
+
+        return redirect()->route('licenses.index')
+                         ->with('success', 'License created successfully.');
+    }
 }

--- a/app/Http/Controllers/LicenseGroupController.php
+++ b/app/Http/Controllers/LicenseGroupController.php
@@ -13,4 +13,22 @@ class LicenseGroupController extends Controller
         $licenseGroups = \App\Models\LicenseGroup::all();
         return view('license-groups.index', compact('licenseGroups'));
     }
+
+    public function create()
+    {
+        return view('license-groups.create');
+    }
+
+    public function store(\Illuminate\Http\Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+
+        \App\Models\LicenseGroup::create($data);
+
+        return redirect()->route('license-groups.index')
+                         ->with('success', 'License group created successfully.');
+    }
 }

--- a/app/Http/Controllers/ServerBackupController.php
+++ b/app/Http/Controllers/ServerBackupController.php
@@ -13,4 +13,30 @@ class ServerBackupController extends Controller
         $serverBackups = \App\Models\ServerBackup::with(['server', 'backupServer'])->get();
         return view('server-backups.index', compact('serverBackups'));
     }
+
+    public function create()
+    {
+        $servers = \App\Models\Server::all();
+        $backupServers = \App\Models\ClientServer::all();
+        return view('server-backups.create', compact('servers', 'backupServers'));
+    }
+
+    public function store(\Illuminate\Http\Request $request)
+    {
+        $data = $request->validate([
+            'server_id' => 'required|integer',
+            'backup_type' => 'required|string|max:255',
+            'backup_server_id' => 'required|integer',
+            'username' => 'required|string|max:255',
+            'password' => 'required|string|max:255',
+            'schedule_day' => 'nullable|integer',
+            'schedule_hour' => 'nullable|integer',
+            'timezone' => 'required|string|max:255',
+        ]);
+
+        \App\Models\ServerBackup::create($data);
+
+        return redirect()->route('server-backups.index')
+                         ->with('success', 'Server backup created successfully.');
+    }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -13,4 +13,26 @@ class UserController extends Controller
         $users = \App\Models\User::all();
         return view('users.index', compact('users'));
     }
+
+    public function create()
+    {
+        return view('users.create');
+    }
+
+    public function store(\Illuminate\Http\Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|string|min:6',
+            'role' => 'required|string|max:255',
+        ]);
+
+        $data['password'] = bcrypt($data['password']);
+
+        \App\Models\User::create($data);
+
+        return redirect()->route('users.index')
+                         ->with('success', 'User created successfully.');
+    }
 }

--- a/resources/views/client-servers/create.blade.php
+++ b/resources/views/client-servers/create.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Add Client Server</h1>
+    <form method="POST" action="{{ route('client-servers.store') }}">
+        @csrf
+        <div class="mb-3">
+            <label for="name" class="form-label">Name</label>
+            <input type="text" name="name" id="name" class="form-control" value="{{ old('name') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="ip_address" class="form-label">IP Address</label>
+            <input type="text" name="ip_address" id="ip_address" class="form-control" value="{{ old('ip_address') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="type" class="form-label">Type</label>
+            <input type="text" name="type" id="type" class="form-control" value="{{ old('type') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="timezone" class="form-label">Timezone</label>
+            <input type="text" name="timezone" id="timezone" class="form-control" value="{{ old('timezone', 'UTC') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" name="username" id="username" class="form-control" value="{{ old('username') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="text" name="password" id="password" class="form-control" value="{{ old('password') }}" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <a href="{{ route('client-servers.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/client-servers/index.blade.php
+++ b/resources/views/client-servers/index.blade.php
@@ -3,6 +3,10 @@
 @section('content')
 <div class="container">
     <h1>Client Servers</h1>
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+    <a href="{{ route('client-servers.create') }}" class="btn btn-primary mb-3">Add Client Server</a>
     <table class="table table-bordered">
         <thead>
             <tr>

--- a/resources/views/license-groups/create.blade.php
+++ b/resources/views/license-groups/create.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Add License Group</h1>
+    <form method="POST" action="{{ route('license-groups.store') }}">
+        @csrf
+        <div class="mb-3">
+            <label for="name" class="form-label">Name</label>
+            <input type="text" name="name" id="name" class="form-control" value="{{ old('name') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="description" class="form-label">Description</label>
+            <textarea name="description" id="description" class="form-control">{{ old('description') }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <a href="{{ route('license-groups.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/license-groups/index.blade.php
+++ b/resources/views/license-groups/index.blade.php
@@ -3,6 +3,10 @@
 @section('content')
 <div class="container">
     <h1>License Groups</h1>
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+    <a href="{{ route('license-groups.create') }}" class="btn btn-primary mb-3">Add License Group</a>
     <table class="table table-bordered">
         <thead>
             <tr>

--- a/resources/views/licenses/create.blade.php
+++ b/resources/views/licenses/create.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Add License</h1>
+    <form method="POST" action="{{ route('licenses.store') }}">
+        @csrf
+        <div class="mb-3">
+            <label for="name" class="form-label">Name</label>
+            <input type="text" name="name" id="name" class="form-control" value="{{ old('name') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="license_key" class="form-label">License Key</label>
+            <input type="text" name="license_key" id="license_key" class="form-control" value="{{ old('license_key') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="provider" class="form-label">Provider</label>
+            <input type="text" name="provider" id="provider" class="form-control" value="{{ old('provider') }}">
+        </div>
+        <div class="mb-3">
+            <label for="type" class="form-label">Type</label>
+            <input type="text" name="type" id="type" class="form-control" value="{{ old('type') }}">
+        </div>
+        <div class="mb-3">
+            <label for="status" class="form-label">Status</label>
+            <input type="text" name="status" id="status" class="form-control" value="{{ old('status') }}">
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <a href="{{ route('licenses.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/licenses/index.blade.php
+++ b/resources/views/licenses/index.blade.php
@@ -3,6 +3,10 @@
 @section('content')
 <div class="container">
     <h1>Licenses</h1>
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+    <a href="{{ route('licenses.create') }}" class="btn btn-primary mb-3">Add License</a>
     <table class="table table-bordered">
         <thead>
             <tr>

--- a/resources/views/server-backups/create.blade.php
+++ b/resources/views/server-backups/create.blade.php
@@ -1,0 +1,54 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Add Server Backup</h1>
+    <form method="POST" action="{{ route('server-backups.store') }}">
+        @csrf
+        <div class="mb-3">
+            <label for="server_id" class="form-label">Server</label>
+            <select name="server_id" id="server_id" class="form-select" required>
+                <option value="">Select</option>
+                @foreach($servers as $server)
+                    <option value="{{ $server->id }}" @selected(old('server_id') == $server->id)>{{ $server->hostname }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div class="mb-3">
+            <label for="backup_type" class="form-label">Backup Type</label>
+            <input type="text" name="backup_type" id="backup_type" class="form-control" value="{{ old('backup_type') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="backup_server_id" class="form-label">Backup Server</label>
+            <select name="backup_server_id" id="backup_server_id" class="form-select" required>
+                <option value="">Select</option>
+                @foreach($backupServers as $server)
+                    <option value="{{ $server->id }}" @selected(old('backup_server_id') == $server->id)>{{ $server->name }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" name="username" id="username" class="form-control" value="{{ old('username') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="text" name="password" id="password" class="form-control" value="{{ old('password') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="schedule_day" class="form-label">Schedule Day</label>
+            <input type="number" name="schedule_day" id="schedule_day" class="form-control" value="{{ old('schedule_day') }}">
+        </div>
+        <div class="mb-3">
+            <label for="schedule_hour" class="form-label">Schedule Hour</label>
+            <input type="number" name="schedule_hour" id="schedule_hour" class="form-control" value="{{ old('schedule_hour') }}">
+        </div>
+        <div class="mb-3">
+            <label for="timezone" class="form-label">Timezone</label>
+            <input type="text" name="timezone" id="timezone" class="form-control" value="{{ old('timezone', 'UTC') }}" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <a href="{{ route('server-backups.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/server-backups/index.blade.php
+++ b/resources/views/server-backups/index.blade.php
@@ -3,6 +3,10 @@
 @section('content')
 <div class="container">
     <h1>Server Backups</h1>
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+    <a href="{{ route('server-backups.create') }}" class="btn btn-primary mb-3">Add Server Backup</a>
     <table class="table table-bordered">
         <thead>
             <tr>

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Add User</h1>
+    <form method="POST" action="{{ route('users.store') }}">
+        @csrf
+        <div class="mb-3">
+            <label for="name" class="form-label">Name</label>
+            <input type="text" name="name" id="name" class="form-control" value="{{ old('name') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" name="email" id="email" class="form-control" value="{{ old('email') }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" name="password" id="password" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="role" class="form-label">Role</label>
+            <input type="text" name="role" id="role" class="form-control" value="{{ old('role') }}" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <a href="{{ route('users.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -3,6 +3,10 @@
 @section('content')
 <div class="container">
     <h1>Users</h1>
+    @if(session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+    <a href="{{ route('users.create') }}" class="btn btn-primary mb-3">Add User</a>
     <table class="table table-bordered">
         <thead>
             <tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,12 +17,22 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/servers', [App\Http\Controllers\ServerController::class, 'store'])->name('servers.store');
 
     Route::get('/clients-servers', [App\Http\Controllers\ClientServerController::class, 'index'])->name('client-servers.index');
+    Route::get('/clients-servers/create', [App\Http\Controllers\ClientServerController::class, 'create'])->name('client-servers.create');
+    Route::post('/clients-servers', [App\Http\Controllers\ClientServerController::class, 'store'])->name('client-servers.store');
 
     Route::get('/server-backups', [App\Http\Controllers\ServerBackupController::class, 'index'])->name('server-backups.index');
+    Route::get('/server-backups/create', [App\Http\Controllers\ServerBackupController::class, 'create'])->name('server-backups.create');
+    Route::post('/server-backups', [App\Http\Controllers\ServerBackupController::class, 'store'])->name('server-backups.store');
 
     Route::get('/licenses', [App\Http\Controllers\LicenseController::class, 'index'])->name('licenses.index');
+    Route::get('/licenses/create', [App\Http\Controllers\LicenseController::class, 'create'])->name('licenses.create');
+    Route::post('/licenses', [App\Http\Controllers\LicenseController::class, 'store'])->name('licenses.store');
 
     Route::get('/license-groups', [App\Http\Controllers\LicenseGroupController::class, 'index'])->name('license-groups.index');
+    Route::get('/license-groups/create', [App\Http\Controllers\LicenseGroupController::class, 'create'])->name('license-groups.create');
+    Route::post('/license-groups', [App\Http\Controllers\LicenseGroupController::class, 'store'])->name('license-groups.store');
 
     Route::get('/users', [App\Http\Controllers\UserController::class, 'index'])->name('users.index');
+    Route::get('/users/create', [App\Http\Controllers\UserController::class, 'create'])->name('users.create');
+    Route::post('/users', [App\Http\Controllers\UserController::class, 'store'])->name('users.store');
 });


### PR DESCRIPTION
## Summary
- add create and store actions across controllers
- register create/store routes
- make creation forms for each resource
- show success messages and add button in list views

## Testing
- `php -l app/Http/Controllers/ClientServerController.php`
- `php -l app/Http/Controllers/ServerBackupController.php`
- `php -l app/Http/Controllers/LicenseController.php`
- `php -l app/Http/Controllers/LicenseGroupController.php`
- `php -l app/Http/Controllers/UserController.php`
- `php -l routes/web.php`
- `php -l resources/views/client-servers/create.blade.php`
- `php -l resources/views/server-backups/create.blade.php`
- `php -l resources/views/licenses/create.blade.php`
- `php -l resources/views/license-groups/create.blade.php`
- `php -l resources/views/users/create.blade.php`
- `php -l resources/views/client-servers/index.blade.php`
- `php -l resources/views/server-backups/index.blade.php`
- `php -l resources/views/licenses/index.blade.php`
- `php -l resources/views/license-groups/index.blade.php`
- `php -l resources/views/users/index.blade.php`

------
https://chatgpt.com/codex/tasks/task_e_68502dbf86cc8324b841725ffbe42b59