### PR TITLE
Add role-based access check for backup servers

### DIFF
--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, string $role): Response
+    {
+        if (!$request->user() || $request->user()->role !== $role) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\CheckRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'admin',
         ];
     }
 
@@ -39,6 +40,13 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    public function viewer(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => 'viewer',
         ]);
     }
 }

--- a/database/migrations/2025_06_20_183802_add_role_to_users_table.php
+++ b/database/migrations/2025_06_20_183802_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('viewer');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Admin',
             'email' => 'admin@example.com',
             'password' => bcrypt('password'),
+            'role' => 'admin',
         ]);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,5 +16,6 @@ Route::middleware('auth')->group(function () {
         return view('dashboard');
     })->name('dashboard');
 
-    Route::resource('backupservers', BackupServerController::class);
+    Route::resource('backupservers', BackupServerController::class)
+        ->middleware('role:admin');
 });

--- a/tests/Feature/BackupServerTest.php
+++ b/tests/Feature/BackupServerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\BackupServer;
+use App\Models\User;
 
 class BackupServerTest extends TestCase
 {
@@ -14,7 +15,7 @@ class BackupServerTest extends TestCase
     {
         BackupServer::factory()->create(['hostname' => 'server1']);
 
-        $this->actingAs(\App\Models\User::factory()->create());
+        $this->actingAs(User::factory()->create());
         $response = $this->get('/backupservers');
 
         $response->assertStatus(200);
@@ -23,7 +24,7 @@ class BackupServerTest extends TestCase
 
     public function test_server_can_be_created_and_updated_and_deleted(): void
     {
-        $this->actingAs(\App\Models\User::factory()->create());
+        $this->actingAs(User::factory()->create());
         $response = $this->post('/backupservers', [
             'hostname' => 'srv',
             'ip_address' => '1.1.1.1',
@@ -41,5 +42,12 @@ class BackupServerTest extends TestCase
         $this->delete("/backupservers/{$server->id}")->assertRedirect('/backupservers');
 
         $this->assertDatabaseMissing('backup_servers', ['id' => $server->id]);
+    }
+
+    public function test_non_admin_role_is_denied_access(): void
+    {
+        $this->actingAs(User::factory()->viewer()->create());
+
+        $this->get('/backupservers')->assertStatus(403);
     }
 }


### PR DESCRIPTION
## Summary
- create `CheckRole` middleware
- register new middleware in `bootstrap/app.php`
- enforce `role:admin` on `backupservers` routes
- store user role and provide factory helper
- seed admin role
- test non-admin access denied

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570462b7788324944a28c0f3e4d483