### PR TITLE
Add client server management and dashboard logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ This project ships with precompiled assets so Node.js or npm is not required.
 
 - Schedule internal, external, database and NAS backups
 - Assign backup servers and track backup settings
+- Manage client servers with simple CRUD screens
 - Group licenses and associate them with servers
 - Role based access control (admin, manager, viewer, custom roles)
 - Assign users to specific servers or clients
 - Highlight conflicting backup times
+- Track user activity logs
 - Dashboard with statistics and upcoming indicators
 
 ## Menu Structure

--- a/app/Http/Controllers/BackupServerController.php
+++ b/app/Http/Controllers/BackupServerController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\BackupServer;
+use App\Models\ActivityLog;
 use Illuminate\Http\Request;
 
 class BackupServerController extends Controller
@@ -21,7 +22,11 @@ class BackupServerController extends Controller
     public function store(Request $request)
     {
         $data = $this->validateData($request);
-        BackupServer::create($data);
+        $server = BackupServer::create($data);
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'action' => "Created backup server {$server->hostname}",
+        ]);
         return redirect()->route('backupservers.index');
     }
 
@@ -34,12 +39,21 @@ class BackupServerController extends Controller
     {
         $data = $this->validateData($request);
         $backupserver->update($data);
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'action' => "Updated backup server {$backupserver->hostname}",
+        ]);
         return redirect()->route('backupservers.index');
     }
 
     public function destroy(BackupServer $backupserver)
     {
+        $name = $backupserver->hostname;
         $backupserver->delete();
+        ActivityLog::create([
+            'user_id' => auth()->id(),
+            'action' => "Deleted backup server {$name}",
+        ]);
         return redirect()->route('backupservers.index');
     }
 

--- a/app/Http/Controllers/ClientServerController.php
+++ b/app/Http/Controllers/ClientServerController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ClientServer;
+use App\Models\ActivityLog;
+use Illuminate\Http\Request;
+
+class ClientServerController extends Controller
+{
+    public function index()
+    {
+        $servers = ClientServer::all();
+        return view('clientservers.index', compact('servers'));
+    }
+
+    public function create()
+    {
+        return view('clientservers.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'hostname' => 'required|string|max:255',
+            'ip_address' => 'required|string|max:255',
+            'location' => 'nullable|string|max:255',
+            'notes' => 'nullable|string',
+        ]);
+        $server = ClientServer::create($data);
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'action' => "Created client server {$server->hostname}",
+        ]);
+        return redirect()->route('clientservers.index');
+    }
+
+    public function edit(ClientServer $clientserver)
+    {
+        return view('clientservers.edit', compact('clientserver'));
+    }
+
+    public function update(Request $request, ClientServer $clientserver)
+    {
+        $data = $request->validate([
+            'hostname' => 'required|string|max:255',
+            'ip_address' => 'required|string|max:255',
+            'location' => 'nullable|string|max:255',
+            'notes' => 'nullable|string',
+        ]);
+        $clientserver->update($data);
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'action' => "Updated client server {$clientserver->hostname}",
+        ]);
+        return redirect()->route('clientservers.index');
+    }
+
+    public function destroy(ClientServer $clientserver)
+    {
+        $name = $clientserver->hostname;
+        $clientserver->delete();
+        ActivityLog::create([
+            'user_id' => auth()->id(),
+            'action' => "Deleted client server {$name}",
+        ]);
+        return redirect()->route('clientservers.index');
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\BackupServer;
+use App\Models\ClientServer;
+use App\Models\BackupSchedule;
+use App\Models\ActivityLog;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        $data = [
+            'client_servers' => ClientServer::count(),
+            'backup_servers' => BackupServer::count(),
+            'upcoming_backups' => BackupSchedule::whereDate('scheduled_at', today())->count(),
+            'recent_logs' => ActivityLog::latest()->take(5)->get(),
+        ];
+
+        return view('dashboard', $data);
+    }
+}

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ActivityLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'action',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/BackupSchedule.php
+++ b/app/Models/BackupSchedule.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class BackupSchedule extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'backup_server_id',
+        'scheduled_at',
+        'type',
+    ];
+
+    protected $casts = [
+        'scheduled_at' => 'datetime',
+    ];
+
+    public function server()
+    {
+        return $this->belongsTo(BackupServer::class, 'backup_server_id');
+    }
+}

--- a/app/Models/ClientServer.php
+++ b/app/Models/ClientServer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ClientServer extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'hostname',
+        'ip_address',
+        'location',
+        'notes',
+    ];
+}

--- a/database/migrations/2025_06_20_183803_create_client_servers_table.php
+++ b/database/migrations/2025_06_20_183803_create_client_servers_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('client_servers', function (Blueprint $table) {
+            $table->id();
+            $table->string('hostname');
+            $table->string('ip_address');
+            $table->string('location')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('client_servers');
+    }
+};

--- a/database/migrations/2025_06_20_183804_create_backup_schedules_table.php
+++ b/database/migrations/2025_06_20_183804_create_backup_schedules_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('backup_schedules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('backup_server_id')->constrained('backup_servers')->onDelete('cascade');
+            $table->dateTime('scheduled_at');
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('backup_schedules');
+    }
+};

--- a/database/migrations/2025_06_20_183805_create_activity_logs_table.php
+++ b/database/migrations/2025_06_20_183805_create_activity_logs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('action');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_logs');
+    }
+};

--- a/resources/views/clientservers/create.blade.php
+++ b/resources/views/clientservers/create.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>Create Client Server</h1>
+    <form method="POST" action="{{ route('clientservers.store') }}">
+        @csrf
+        <div>
+            <label>Hostname
+                <input type="text" name="hostname" required>
+            </label>
+        </div>
+        <div>
+            <label>IP Address
+                <input type="text" name="ip_address" required>
+            </label>
+        </div>
+        <div>
+            <label>Location
+                <input type="text" name="location">
+            </label>
+        </div>
+        <div>
+            <label>Notes
+                <textarea name="notes"></textarea>
+            </label>
+        </div>
+        <button type="submit">Save</button>
+    </form>
+@endsection

--- a/resources/views/clientservers/edit.blade.php
+++ b/resources/views/clientservers/edit.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>Edit Client Server</h1>
+    <form method="POST" action="{{ route('clientservers.update', $clientserver) }}">
+        @csrf
+        @method('PUT')
+        <div>
+            <label>Hostname
+                <input type="text" name="hostname" value="{{ $clientserver->hostname }}" required>
+            </label>
+        </div>
+        <div>
+            <label>IP Address
+                <input type="text" name="ip_address" value="{{ $clientserver->ip_address }}" required>
+            </label>
+        </div>
+        <div>
+            <label>Location
+                <input type="text" name="location" value="{{ $clientserver->location }}">
+            </label>
+        </div>
+        <div>
+            <label>Notes
+                <textarea name="notes">{{ $clientserver->notes }}</textarea>
+            </label>
+        </div>
+        <button type="submit">Update</button>
+    </form>
+@endsection

--- a/resources/views/clientservers/index.blade.php
+++ b/resources/views/clientservers/index.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>Client Servers</h1>
+    <a href="{{ route('clientservers.create') }}">Add Client Server</a>
+    <ul>
+        @foreach ($servers as $server)
+            <li>
+                {{ $server->hostname }} ({{ $server->ip_address }})
+                <a href="{{ route('clientservers.edit', $server) }}">Edit</a>
+                <form method="POST" action="{{ route('clientservers.destroy', $server) }}" style="display:inline">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit">Delete</button>
+                </form>
+            </li>
+        @endforeach
+    </ul>
+@endsection

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,6 +1,17 @@
 @extends('layouts.app')
 
 @section('content')
-<h1>Dashboard</h1>
-<p>You're logged in.</p>
+    <h1>Dashboard</h1>
+    <ul>
+        <li>Total Client Servers: {{ $client_servers }}</li>
+        <li>Total Backup Servers: {{ $backup_servers }}</li>
+        <li>Upcoming Backups Today: {{ $upcoming_backups }}</li>
+    </ul>
+
+    <h2>Recent Activity</h2>
+    <ul>
+        @foreach ($recent_logs as $log)
+            <li>{{ $log->created_at }} - {{ $log->action }}</li>
+        @endforeach
+    </ul>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\Auth\LoginController;
 
 Route::redirect('/', '/login');
 use App\Http\Controllers\BackupServerController;
+use App\Http\Controllers\ClientServerController;
+use App\Http\Controllers\DashboardController;
 
 // Authentication
 Route::get('/login', [LoginController::class, 'showLoginForm'])->name('login');
@@ -12,10 +14,11 @@ Route::post('/login', [LoginController::class, 'login']);
 Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
 
 Route::middleware(['auth', 'can:access-admin-sections'])->group(function () {
-    Route::get('/dashboard', function () {
-        return view('dashboard');
-    })->name('dashboard');
+    Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
     Route::resource('backupservers', BackupServerController::class)
+        ->middleware('role:admin');
+
+    Route::resource('clientservers', ClientServerController::class)
         ->middleware('role:admin');
 });


### PR DESCRIPTION
## Summary
- allow tracking of user activity
- add client server CRUD screens
- log changes to backup and client servers
- show statistics on dashboard
- wire dashboard controller and routes

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685732b298bc832481e849b18fba095a