### PR TITLE
Implement basic license and schedule management

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project ships with precompiled assets so Node.js or npm is not required.
 - Assign users to specific servers or clients
 - Highlight conflicting backup times
 - Track user activity logs
+- Schedule backups with conflict detection
 - Dashboard with statistics and upcoming indicators
 
 ## Menu Structure
@@ -70,3 +71,8 @@ php artisan migrate --seed
 ```
 
 Then start the server with `php artisan serve`.
+
+## Default Admin Credentials
+
+- Email: admin@example.com
+- Password: 123456

--- a/app/Http/Controllers/BackupScheduleController.php
+++ b/app/Http/Controllers/BackupScheduleController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\BackupSchedule;
+use App\Models\BackupServer;
+use App\Models\ActivityLog;
+use Illuminate\Http\Request;
+
+class BackupScheduleController extends Controller
+{
+    public function index()
+    {
+        $schedules = BackupSchedule::with('server')->orderBy('scheduled_at')->get();
+        return view('schedules.index', compact('schedules'));
+    }
+
+    public function create()
+    {
+        $servers = BackupServer::pluck('hostname', 'id');
+        return view('schedules.create', compact('servers'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'backup_server_id' => 'required|exists:backup_servers,id',
+            'scheduled_at' => 'required|date',
+            'type' => 'required|string|max:255',
+        ]);
+
+        $conflict = BackupSchedule::where('scheduled_at', $data['scheduled_at'])->exists();
+        if ($conflict) {
+            return back()->withErrors(['scheduled_at' => 'Time conflict with another backup.'])->withInput();
+        }
+
+        $schedule = BackupSchedule::create($data);
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'action' => "Scheduled backup {$schedule->type} on {$schedule->scheduled_at}",
+        ]);
+        return redirect()->route('schedules.index');
+    }
+
+    public function destroy(BackupSchedule $schedule)
+    {
+        $info = $schedule->scheduled_at;
+        $schedule->delete();
+        ActivityLog::create([
+            'user_id' => auth()->id(),
+            'action' => "Deleted schedule {$info}",
+        ]);
+        return redirect()->route('schedules.index');
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -6,6 +6,7 @@ use App\Models\BackupServer;
 use App\Models\ClientServer;
 use App\Models\BackupSchedule;
 use App\Models\ActivityLog;
+use App\Models\License;
 
 class DashboardController extends Controller
 {
@@ -14,7 +15,8 @@ class DashboardController extends Controller
         $data = [
             'client_servers' => ClientServer::count(),
             'backup_servers' => BackupServer::count(),
-            'upcoming_backups' => BackupSchedule::whereDate('scheduled_at', today())->count(),
+            'licenses' => License::count(),
+            'todays_schedules' => BackupSchedule::with('server')->whereDate('scheduled_at', today())->get(),
             'recent_logs' => ActivityLog::latest()->take(5)->get(),
         ];
 

--- a/app/Http/Controllers/LicenseController.php
+++ b/app/Http/Controllers/LicenseController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\License;
+use App\Models\ClientServer;
+use App\Models\ActivityLog;
+use Illuminate\Http\Request;
+
+class LicenseController extends Controller
+{
+    public function index()
+    {
+        $licenses = License::with('clientServer')->get();
+        return view('licenses.index', compact('licenses'));
+    }
+
+    public function create()
+    {
+        $clients = ClientServer::pluck('hostname', 'id');
+        return view('licenses.create', compact('clients'));
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'key' => 'required|string|max:255',
+            'expiry_date' => 'nullable|date',
+            'client_server_id' => 'required|exists:client_servers,id',
+        ]);
+        $license = License::create($data);
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'action' => "Created license {$license->key}",
+        ]);
+        return redirect()->route('licenses.index');
+    }
+
+    public function edit(License $license)
+    {
+        $clients = ClientServer::pluck('hostname', 'id');
+        return view('licenses.edit', compact('license', 'clients'));
+    }
+
+    public function update(Request $request, License $license)
+    {
+        $data = $request->validate([
+            'key' => 'required|string|max:255',
+            'expiry_date' => 'nullable|date',
+            'client_server_id' => 'required|exists:client_servers,id',
+        ]);
+        $license->update($data);
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'action' => "Updated license {$license->key}",
+        ]);
+        return redirect()->route('licenses.index');
+    }
+
+    public function destroy(License $license)
+    {
+        $key = $license->key;
+        $license->delete();
+        ActivityLog::create([
+            'user_id' => auth()->id(),
+            'action' => "Deleted license {$key}",
+        ]);
+        return redirect()->route('licenses.index');
+    }
+}

--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -10,12 +10,11 @@ class CheckRole
 {
     /**
      * Handle an incoming request.
-     *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
-    public function handle(Request $request, Closure $next, string $role): Response
+    public function handle(Request $request, Closure $next, string $roles): Response
     {
-        if (!$request->user() || $request->user()->role !== $role) {
+        $allowed = array_map('trim', preg_split('/[|,]/', $roles));
+        if (! $request->user() || ! in_array($request->user()->role, $allowed)) {
             abort(403);
         }
 

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class License extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'key',
+        'expiry_date',
+        'client_server_id',
+    ];
+
+    protected $casts = [
+        'expiry_date' => 'date',
+    ];
+
+    public function clientServer()
+    {
+        return $this->belongsTo(ClientServer::class);
+    }
+}

--- a/database/migrations/2025_06_20_183806_create_licenses_table.php
+++ b/database/migrations/2025_06_20_183806_create_licenses_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('licenses', function (Blueprint $table) {
+            $table->id();
+            $table->string('key');
+            $table->date('expiry_date')->nullable();
+            $table->foreignId('client_server_id')->constrained('client_servers')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('licenses');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,12 +12,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
         User::factory()->create([
             'name' => 'Admin',
             'email' => 'admin@example.com',
-            'password' => bcrypt('password'),
+            'password' => bcrypt('123456'),
             'role' => 'admin',
         ]);
     }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,14 +1,23 @@
 @extends('layouts.app')
 
 @section('content')
-    <h1>Dashboard</h1>
-    <ul>
+    <h1 class="text-xl font-bold mb-4">Dashboard</h1>
+    <ul class="mb-4">
         <li>Total Client Servers: {{ $client_servers }}</li>
         <li>Total Backup Servers: {{ $backup_servers }}</li>
-        <li>Upcoming Backups Today: {{ $upcoming_backups }}</li>
+        <li>Total Licenses: {{ $licenses }}</li>
     </ul>
 
-    <h2>Recent Activity</h2>
+    <h2 class="font-semibold">Today's Backups</h2>
+    <ul class="mb-4">
+        @forelse ($todays_schedules as $schedule)
+            <li>{{ $schedule->scheduled_at }} - {{ $schedule->server->hostname }} - {{ $schedule->type }}</li>
+        @empty
+            <li>No backups scheduled today.</li>
+        @endforelse
+    </ul>
+
+    <h2 class="font-semibold">Recent Activity</h2>
     <ul>
         @foreach ($recent_logs as $log)
             <li>{{ $log->created_at }} - {{ $log->action }}</li>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,8 +3,20 @@
 <head>
     <meta charset="UTF-8">
     <title>Backup Manager</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body>
+<body class="p-4">
+    <nav class="mb-4 space-x-4">
+        <a href="{{ route('dashboard') }}">Dashboard</a>
+        <a href="{{ route('backupservers.index') }}">Backup Servers</a>
+        <a href="{{ route('clientservers.index') }}">Client Servers</a>
+        <a href="{{ route('licenses.index') }}">Licenses</a>
+        <a href="{{ route('schedules.index') }}">Schedules</a>
+        <form method="POST" action="{{ route('logout') }}" class="inline">
+            @csrf
+            <button type="submit">Logout</button>
+        </form>
+    </nav>
     @yield('content')
 </body>
 </html>

--- a/resources/views/licenses/create.blade.php
+++ b/resources/views/licenses/create.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>Add License</h1>
+    <form method="POST" action="{{ route('licenses.store') }}">
+        @csrf
+        <label>Key</label>
+        <input type="text" name="key" value="{{ old('key') }}" required>
+        <label>Expiry Date</label>
+        <input type="date" name="expiry_date" value="{{ old('expiry_date') }}">
+        <label>Client Server</label>
+        <select name="client_server_id" required>
+            @foreach ($clients as $id => $name)
+                <option value="{{ $id }}" @selected(old('client_server_id') == $id)>{{ $name }}</option>
+            @endforeach
+        </select>
+        <button type="submit">Save</button>
+    </form>
+@endsection

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>Edit License</h1>
+    <form method="POST" action="{{ route('licenses.update', $license) }}">
+        @csrf
+        @method('PUT')
+        <label>Key</label>
+        <input type="text" name="key" value="{{ old('key', $license->key) }}" required>
+        <label>Expiry Date</label>
+        <input type="date" name="expiry_date" value="{{ old('expiry_date', optional($license->expiry_date)->format('Y-m-d')) }}">
+        <label>Client Server</label>
+        <select name="client_server_id" required>
+            @foreach ($clients as $id => $name)
+                <option value="{{ $id }}" @selected(old('client_server_id', $license->client_server_id) == $id)>{{ $name }}</option>
+            @endforeach
+        </select>
+        <button type="submit">Save</button>
+    </form>
+@endsection

--- a/resources/views/licenses/index.blade.php
+++ b/resources/views/licenses/index.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>Licenses</h1>
+    <a href="{{ route('licenses.create') }}">Add License</a>
+    <ul>
+        @foreach ($licenses as $license)
+            <li>
+                {{ $license->key }} - {{ optional($license->expiry_date)->format('Y-m-d') }} - {{ $license->clientServer->hostname }}
+                <a href="{{ route('licenses.edit', $license) }}">Edit</a>
+                <form method="POST" action="{{ route('licenses.destroy', $license) }}" style="display:inline">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit">Delete</button>
+                </form>
+            </li>
+        @endforeach
+    </ul>
+@endsection

--- a/resources/views/schedules/create.blade.php
+++ b/resources/views/schedules/create.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>Add Backup Schedule</h1>
+    <form method="POST" action="{{ route('schedules.store') }}">
+        @csrf
+        <label>Backup Server</label>
+        <select name="backup_server_id" required>
+            @foreach ($servers as $id => $name)
+                <option value="{{ $id }}" @selected(old('backup_server_id') == $id)>{{ $name }}</option>
+            @endforeach
+        </select>
+        <label>Type</label>
+        <input type="text" name="type" value="{{ old('type') }}" required>
+        <label>Scheduled At</label>
+        <input type="datetime-local" name="scheduled_at" value="{{ old('scheduled_at') }}" required>
+        @error('scheduled_at')<div>{{ $message }}</div>@enderror
+        <button type="submit">Save</button>
+    </form>
+@endsection

--- a/resources/views/schedules/index.blade.php
+++ b/resources/views/schedules/index.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>Backup Schedules</h1>
+    <a href="{{ route('schedules.create') }}">Add Schedule</a>
+    <ul>
+        @foreach ($schedules as $schedule)
+            <li>
+                {{ $schedule->server->hostname }} - {{ $schedule->type }} - {{ $schedule->scheduled_at }}
+                <form method="POST" action="{{ route('schedules.destroy', $schedule) }}" style="display:inline">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit">Delete</button>
+                </form>
+            </li>
+        @endforeach
+    </ul>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,11 +2,13 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\LoginController;
-
-Route::redirect('/', '/login');
 use App\Http\Controllers\BackupServerController;
 use App\Http\Controllers\ClientServerController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\LicenseController;
+use App\Http\Controllers\BackupScheduleController;
+
+Route::redirect('/', '/login');
 
 // Authentication
 Route::get('/login', [LoginController::class, 'showLoginForm'])->name('login');
@@ -17,8 +19,15 @@ Route::middleware(['auth', 'can:access-admin-sections'])->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
     Route::resource('backupservers', BackupServerController::class)
-        ->middleware('role:admin');
+        ->middleware('role:admin|manager');
 
     Route::resource('clientservers', ClientServerController::class)
-        ->middleware('role:admin');
+        ->middleware('role:admin|manager');
+
+    Route::resource('licenses', LicenseController::class)
+        ->middleware('role:admin|manager');
+
+    Route::resource('schedules', BackupScheduleController::class)
+        ->only(['index', 'create', 'store', 'destroy'])
+        ->middleware('role:admin|manager');
 });


### PR DESCRIPTION
## Summary
- create License model, migration, controller and views
- add BackupSchedule controller and views with simple conflict check
- extend dashboard stats to show licenses and today schedules
- update layout navigation and README credentials
- allow multiple roles in `CheckRole` middleware

## Testing
- `php artisan migrate --seed` *(fails: could not find driver)*
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_685e063da6608324888d958a3ddbba75